### PR TITLE
Add ability to adjust screen timing

### DIFF
--- a/config.py.sample
+++ b/config.py.sample
@@ -32,3 +32,13 @@ FULLSCREEN = True
 # If the weather icons are overlapping the text try adjusting
 # this value. Negative values raise the icon.
 LARGE_ICON_OFFSET = -23.5
+
+# Number of seconds to pause on the Daily and Hourly weather screens.
+DH_PAUSE = 60 # 1 minute
+
+# Number of seconds to pause on the Info screen.
+INFO_SCREEN_PAUSE = 300 # 5 minutes
+
+# Number of seconds between showing the info screen.
+INFO_SCREEN_DELAY = 900 # 15 minutes
+

--- a/config.py.sample
+++ b/config.py.sample
@@ -33,8 +33,11 @@ FULLSCREEN = True
 # this value. Negative values raise the icon.
 LARGE_ICON_OFFSET = -23.5
 
-# Number of seconds to pause on the Daily and Hourly weather screens.
-DH_PAUSE = 60 # 1 minute
+# Number of seconds to pause on the Daily weather screen.
+DAILY_PAUSE = 60 # 1 minute
+
+# Number of seconds to pause on the Hourly weather screen. 
+HOURLY_PAUSE = 60 # 1 minute
 
 # Number of seconds to pause on the Info screen.
 INFO_SCREEN_PAUSE = 300 # 5 minutes

--- a/weather.py
+++ b/weather.py
@@ -887,7 +887,6 @@ while RUNNING:
             syslog.syslog("Switching to info mode")
         elif (PERIODIC_INFO_ACTIVATION % (((config.DAILY_PAUSE * D_COUNT) +
               (config.HOURLY_PAUSE * H_COUNT)) * 10)) == 0:
-            syslog.syslog("Time: " + str(PERIODIC_INFO_ACTIVATION / 10))
             if MODE == 'd':
                 syslog.syslog("Switching to HOURLY")
                 MODE = 'h'

--- a/weather.py
+++ b/weather.py
@@ -880,12 +880,10 @@ while RUNNING:
         if PERIODIC_INFO_ACTIVATION > (config.INFO_SCREEN_DELAY * 10):
             MODE = 'i'
             syslog.syslog("Switched to info mode")
-        elif (
-              PERIODIC_INFO_ACTIVATION % (config.DH_PAUSE * 10)) == 0 and
+        elif (PERIODIC_INFO_ACTIVATION % (config.DH_PAUSE * 10)) == 0 and
               MODE == 'd'):
             MODE = 'h'
-        elif (
-              PERIODIC_INFO_ACTIVATION % (config.DH_PAUSE * 10)) == 0 and
+        elif (PERIODIC_INFO_ACTIVATION % (config.DH_PAUSE * 10)) == 0 and
               MODE == 'h'):
             MODE = 'd'
 
@@ -950,4 +948,3 @@ while RUNNING:
 
 
 pygame.quit()
-

--- a/weather.py
+++ b/weather.py
@@ -868,21 +868,25 @@ while RUNNING:
     if MODE not in ('d', 'h'):
         PERIODIC_INFO_ACTIVATION = 0
         NON_WEATHER_TIMEOUT += 1
-        # Five minute timeout at 100ms loop rate.
-        if NON_WEATHER_TIMEOUT > 3000:
+        # Default in config.py.sample: pause for 5 minutes on info screen
+        if NON_WEATHER_TIMEOUT > (config.INFO_SCREEN_PAUSE * 10):
             MODE = 'd'
             syslog.syslog("Switched to weather mode")
     else:
         NON_WEATHER_TIMEOUT = 0
         PERIODIC_INFO_ACTIVATION += 1
-        CURR_MIN_INT = int(datetime.datetime.now().strftime("%M"))
-        # 15 minute timeout at 100ms loop rate
-        if PERIODIC_INFO_ACTIVATION > 9000:
+        # Default in config.py.sample: flip between 2 weather screens
+        # for 15 minutes before showing info screen.
+        if PERIODIC_INFO_ACTIVATION > (config.INFO_SCREEN_DELAY * 10):
             MODE = 'i'
             syslog.syslog("Switched to info mode")
-        elif PERIODIC_INFO_ACTIVATION > 600 and CURR_MIN_INT % 2 == 0:
+        elif (
+              PERIODIC_INFO_ACTIVATION % (config.DH_PAUSE * 10)) == 0 and
+              MODE == 'd'):
             MODE = 'h'
-        elif PERIODIC_INFO_ACTIVATION > 600:
+        elif (
+              PERIODIC_INFO_ACTIVATION % (config.DH_PAUSE * 10)) == 0 and
+              MODE == 'h'):
             MODE = 'd'
 
     # Daily Weather Display Mode
@@ -946,3 +950,4 @@ while RUNNING:
 
 
 pygame.quit()
+


### PR DESCRIPTION
This pull request adds three variables to the `config.py.sample`, and amends `weather.py` to accept these variables. It was written to be backward compatible with what current users are accustomed to seeing.

## config.py.sample additions:
```
# Number of seconds to pause on the Daily and Hourly weather screens.
DH_PAUSE = 60 # 1 minute

# Number of seconds to pause on the Info screen.
INFO_SCREEN_PAUSE = 300 # 5 minutes

# Number of seconds between showing the info screen.
INFO_SCREEN_DELAY = 900 # 15 minutes
```

## weather.py amendments (line 867+):
```
    # Automatically switch back to weather display after a couple minutes.
    if MODE not in ('d', 'h'):
        PERIODIC_INFO_ACTIVATION = 0
        NON_WEATHER_TIMEOUT += 1
        # Default in config.py.sample: pause for 5 minutes on info screen
        if NON_WEATHER_TIMEOUT > (config.INFO_SCREEN_PAUSE * 10):
            MODE = 'd'
            syslog.syslog("Switched to weather mode")
    else:
        NON_WEATHER_TIMEOUT = 0
        PERIODIC_INFO_ACTIVATION += 1
        # Default in config.py.sample: flip between 2 weather screens
        # for 15 minutes before showing info screen.
        if PERIODIC_INFO_ACTIVATION > (config.INFO_SCREEN_DELAY * 10):
            MODE = 'i'
            syslog.syslog("Switched to info mode")
        elif (PERIODIC_INFO_ACTIVATION % (config.DH_PAUSE * 10)) == 0 and
              MODE == 'd'):
            MODE = 'h'
        elif (PERIODIC_INFO_ACTIVATION % (config.DH_PAUSE * 10)) == 0 and
              MODE == 'h'):
            MODE = 'd'
```