### PR TITLE
Pin automated setup to named release

### DIFF
--- a/setup.pp
+++ b/setup.pp
@@ -86,9 +86,10 @@ exec { 'enable display-setup-script':
 }
 
 vcsrepo { '/home/pi/PiWeatherRock':
-  ensure   => latest,
+  ensure   => present,
   provider => git,
   source   => 'https://github.com/genebean/PiWeatherRock.git',
+  revision => '1.3.0',
 }
 
 $python_packages = [


### PR DESCRIPTION
Starting with this commit, the part of setup.pp that makes sure things
are right git-wise will pin to a git tag. Initially, this is 1.3.0 as
this is likely to be the last version before some major changes land on
the master branch.