### PR TITLE
Defining 12hour_disp in config.sample

### DIFF
--- a/config.json-sample
+++ b/config.json-sample
@@ -6,6 +6,7 @@
     "units": "us",
     "lang": "en",
     "fullscreen": true,
+    "12hour_disp": true,
     "icon_offset": -23.5,
     "update_freq": 300,
     "info_pause": 300,


### PR DESCRIPTION
After the pip3 upgrade, The program failed due to the missing "12hour_disp" in config. Added iy to the sample file.